### PR TITLE
Update API baseURL to match public API change

### DIFF
--- a/src/datasources/categories.js
+++ b/src/datasources/categories.js
@@ -3,7 +3,7 @@ const { RESTDataSource } = require("apollo-datasource-rest");
 class CategoriesAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = "https://eonet.sci.gsfc.nasa.gov/api/v3/";
+    this.baseURL = "https://eonet.gsfc.nasa.gov/api/v3/";
   }
 
   async queryAllVolcanoes() {

--- a/src/datasources/events.js
+++ b/src/datasources/events.js
@@ -3,7 +3,7 @@ const { RESTDataSource } = require("apollo-datasource-rest");
 class EventsAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = "https://eonet.sci.gsfc.nasa.gov/api/v3/";
+    this.baseURL = "https://eonet.gsfc.nasa.gov/api/v3/";
   }
 
   async queryAllEvents() {


### PR DESCRIPTION
I did not dig into history here, but the API moved from https://eonet.sci.gsfc.nasa.gov/api/v3 to https://eonet.gsfc.nasa.gov/api/v3/

This simply adjusts that fact. Thank you! Appreciate the hard work here.